### PR TITLE
timeout 120

### DIFF
--- a/lib/wmiquery.py
+++ b/lib/wmiquery.py
@@ -19,6 +19,7 @@ DTYPS_NOT_NULL = {
     float: 0.,
     list: [],
 }
+QUERY_TIMEOUT = 120
 
 
 async def wmiconn(
@@ -70,7 +71,7 @@ async def wmiquery(
     rows = []
 
     try:
-        async with query.context(conn, service) as qc:
+        async with query.context(conn, service, timeout=QUERY_TIMEOUT) as qc:
             async for props in qc.results():
                 row = {}
                 for name, prop in props.items():


### PR DESCRIPTION
## Description

Increase time-out on wmi queries. This is particularly useful for the software check which might take a long time.

_Note that the time-out might take longer than the check timeout when a very low interval is chosen_

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
